### PR TITLE
Restructure api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,33 +100,38 @@ From these definitions, the following digrams are generated:
 
 ##### Example
 ``` TypeScript
-import { System, UI, Service, Database, Device, ConnectsTo } from "trellisuml";
+import { system, ui, service, database, device, connectsTo } from "trellisuml";
 // These would typically be defined in a "domain" diagram & imported from that diagram instead of defined here.
 // because they are likely re-used by other components in other systems/solutions
-const clientDevice = new Device("Mobile App");
-const appServer = new Device("Application Server");
-const dbServer = new Device("Database Server");
+const [ clientDevice, appServer, dbServer ] = device([
+    { label: "Mobile App" },
+    { label: "Application Server"},
+    { label: "Database Server"}
+]);
  
 const name = "Appointments";
 // parentComponents are defined here to place the component in the broader context of the systems & infrastructure.
-const app = new UI(`${name} App`, { parentComponent: clientDevice }); 
-const service = new Service(`${name} Service`, { parentComponent: appServer });
-const db = new Database(`${name} Database`, { parentComponent: dbServer });
+export const apptApp = ui(`${name} App`, clientDevice); 
+export const apptService = service(`${name} Service`, appServer);
+export const apptDb = database(`${name} Database`, dbServer);
 
-export default new System({
+// Defined as needed for every connection between systems. De-duplicated when rendered as puml.
+export const relationships = [
+    connectsTo(apptApp, apptService),
+    connectsTo(apptService, apptDb),
+    connectsTo(clientDevice, appServer, "Ports: 443\\nProtcol:TCP"),
+    connectsTo(appServer, dbServer, "Ports: 1443\\nProtcol:TCP")
+]
+
+export default system({
     name,
-    components: {         // Only the highest level components in the system should be included here.
-        clientDevice,     // Rarely, a component without a parentComponent may be defined in a system diagram.
-        appServer,        // If so, add it here (but it should probably be in the domain diagram module).
-        dbServer,
-    },
-    relationships: {  // Defined as needed for every connection between systems. De-duplicated when rendered as puml.
-        appToService: new ConnectsTo(app, service),
-        serviceToDb: new ConnectsTo(service, db),
-        clientToServer: new ConnectsTo(clientDevice, appServer, "Ports: 443\\nProtcol:TCP"),
-        serverToDb: new ConnectsTo(appServer, dbServer, "Ports: 1443\\nProtcol:TCP")
-    }
-})
+    components: [
+        apptApp,
+        apptService,
+        apptDb,
+    ],
+    relationships,
+});
 ```
 #### Service
 WIP: implement this, write docs.

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,34 +1,12 @@
 #!/usr/bin/env node
 import * as Commands from './cli';
 
+export * from './syntax';
+
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .usage('Usage: $0 [init|generate|serve]')
     .demandCommand(1)
     .argv;
-
-export { 
-    System,
-    SystemConfiguration,
-    ComponentConfiguration,
-    Database,
-    Service,
-    UI,
-    API,
-    Queue,
-    Cache,
-    Processor,
-    Domain,
-    Device,
-    ExecutionEnvironment,
-    ComponentType,
-    ComponentRelationshipConfiguration,
-    Uses,
-    Accesses,
-    FlowsInto,
-    Provides,
-    Requires,
-    ConnectsTo,
-} from "./models"
 
 const { _: [ command, type, name ] = []} = argv;
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-export { generateDiagramScaffold } from './generate';
-export { initializeProject } from './init';
-export { serveProject } from './serve';
-export { buildProject } from './build';
+export * from './generate';
+export * from './init';
+export * from './serve';
+export * from './build';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,2 +1,2 @@
-export { generateSystemDiagrams } from './generate';
-export { escapeString } from './utils';
+export * from './generate';
+export * from './utils';

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,3 +1,3 @@
 export function escapeString(label: string) {
-    return label.replace(/[\/ ]/g, "_").replace(/[\(\)]/g, "")
+    return label.replace(/[\/ ]/g, "_").replace(/[\(\),]/g, "").replace(/\\n/g, "");
 }

--- a/src/models/diagram-root.ts
+++ b/src/models/diagram-root.ts
@@ -1,6 +1,6 @@
 import { System, Domain } from ".";
 
 export interface DiagramRoot {
-    domains: { [key: string]: Domain };
+    domainComponents: { [key: string]: Domain };
     systems: { [key: string]: System };
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,34 +1,4 @@
-export {
-    ComponentConfiguration,
-    Database,
-    Service,
-    UI,
-    API,
-    Queue,
-    Cache,
-    Processor,
-    Domain,
-    Device,
-    ExecutionEnvironment,
-    ComponentType
-}
-from './component'
-
-export {
-    ComponentRelationshipConfiguration,
-    Uses,
-    Accesses,
-    FlowsInto,
-    Provides,
-    Requires,
-    ConnectsTo,
-} from './component-relationship'
-
-export {
-    SystemConfiguration,
-    System,
-} from './system';
-
-export {
-    DiagramRoot
-} from './diagram-root';
+export * from "./component";
+export * from "./component-relationship";
+export * from "./diagram-root";
+export * from "./system";

--- a/src/models/system.ts
+++ b/src/models/system.ts
@@ -6,18 +6,18 @@ export class System implements SystemConfiguration {
     name: string;
     _id: string;
     color?: string;
-    components: { [key: string]: Component };
-    relationships: { [key: string]: ComponentRelationship };
+    components: Array<Component>;
+    relationships: Array<ComponentRelationship>;
     systemDependencies?: {
-        systems?: { [key: string]: System },
-        relationships?: { [key: string]: ComponentRelationship }
+        systems?: Array<System>,
+        relationships?: Array<ComponentRelationship>,
     }
     constructor(config: SystemConfiguration) {
         this.name = config.name;
         this.id = config.name;
         this.components = config.components;
         this.relationships = config.relationships;
-        this.systemDependencies = config?.systemDependencies || { systems: {}, relationships: {}};
+        this.systemDependencies = config?.systemDependencies || { systems: [], relationships: []};
     }
     public get id() {
         return this._id;
@@ -32,10 +32,10 @@ export interface SystemConfiguration {
     name: string;
     id?: string;
     color?: string;
-    components: { [key: string]: Component };
-    relationships: { [key: string]: ComponentRelationship };
+    components: Array<Component>;
+    relationships: Array<ComponentRelationship>;
     systemDependencies?: {
-        systems?: { [key: string]: System },
-        relationships?: { [key: string]: ComponentRelationship }
+        systems?: Array<System>,
+        relationships?: Array<ComponentRelationship>
     }
 }

--- a/src/plantuml/component-diagram.ts
+++ b/src/plantuml/component-diagram.ts
@@ -79,11 +79,11 @@ function generateComponentRelationships(relationships: Array<ComponentRelationsh
 export function generateComponentDiagram(system: System): string {
     const componentsToRender = new Map();
 
-    Object.values(system.components).forEach((component) => {
+    system.components.forEach((component) => {
         if(componentsToRender.has(component.id) === false) componentsToRender.set(component.id, component);
     })
 
-    Object.values(system.relationships).forEach(({source, target}) => {
+    system.relationships.forEach(({source, target}) => {
         if(componentsToRender.has(source.id) === false) componentsToRender.set(source.id, source);
         if(componentsToRender.has(target.id) === false) componentsToRender.set(target.id, target);
     })
@@ -92,7 +92,7 @@ export function generateComponentDiagram(system: System): string {
     output += titleAndHeader(system.name, "Component");
     output += generateSystemMarkup(system) + "{\n"
     output += generateComponents(Array.from(componentsToRender.values()));
-    output += generateComponentRelationships(Object.values(system.relationships));
+    output += generateComponentRelationships(system.relationships);
     output += "}\n";
     output += endUml();
     return output;

--- a/src/plantuml/deployment-diagram.ts
+++ b/src/plantuml/deployment-diagram.ts
@@ -101,7 +101,7 @@ export function generateDeploymentDiagram(system: System): string {
     const componentsToRender = new Map();
     const relationshipComponents = new Map();
     // TODO: come back to consolidate/simplify this probably by changing to arrays.
-    Object.values(system.relationships).forEach(({source, target}) => {
+    system.relationships.forEach(({source, target}) => {
         if(componentsToRender.has(source.id) === false) componentsToRender.set(source.id, source);
         if(componentsToRender.has(target.id) === false) componentsToRender.set(target.id, target);
         if(relationshipComponents.has(target.id) === false) relationshipComponents.set(target.id, target);
@@ -113,13 +113,13 @@ export function generateDeploymentDiagram(system: System): string {
         if (topLevelComponents.has(targetId) === false) topLevelComponents.set(targetId, topTargetComponent);
     })
 
-    Object.values(system.components).forEach((component) => {
+    system.components.forEach((component) => {
         const topComponent = recurseParentComponents(component, componentsToRender);
         const { id } = topComponent;
         if (topLevelComponents.has(id) === false) topLevelComponents.set(id, topComponent);
     });
 
-    Object.values(system.relationships).forEach(({source, target}) => {
+    system.relationships.forEach(({source, target}) => {
         if(componentsToRender.has(source.id) === false) componentsToRender.set(source.id, source);
         if(componentsToRender.has(target.id) === false) componentsToRender.set(target.id, target);
     })
@@ -127,7 +127,7 @@ export function generateDeploymentDiagram(system: System): string {
     // Identify top level components (ones without execution environments) and generate markup recursively.
     output += generateComponents(Array.from(topLevelComponents.values()), componentsToRender);
     // Filter in relationships that connect to an execution environment & generate markup.
-    output += generateRelationships(Object.values(system.relationships));
+    output += generateRelationships(system.relationships);
     output += endUml();
     return output;
 }

--- a/src/plantuml/network-diagram.ts
+++ b/src/plantuml/network-diagram.ts
@@ -84,7 +84,7 @@ export function generateNetworkDiagram(system: System): string {
     const componentsToRender = new Map();
     const relationshipComponents = new Map();
     // TODO: come back to consolidate/simplify this probably by changing to arrays.
-    Object.values(system.relationships).forEach(({source, target}) => {
+    system.relationships.forEach(({source, target}) => {
         if(componentsToRender.has(source.id) === false) componentsToRender.set(source.id, source);
         if(componentsToRender.has(target.id) === false) componentsToRender.set(target.id, target);
         if(relationshipComponents.has(target.id) === false) relationshipComponents.set(target.id, target);
@@ -96,7 +96,7 @@ export function generateNetworkDiagram(system: System): string {
         if (topLevelComponents.has(targetId) === false) topLevelComponents.set(targetId, topTargetComponent);
     })
 
-    Object.values(system.components).forEach((component) => {
+    system.components.forEach((component) => {
         const topComponent = recurseParentComponents(component, componentsToRender);
         const { id } = topComponent;
         if (topLevelComponents.has(id) === false) topLevelComponents.set(id, topComponent);
@@ -105,7 +105,7 @@ export function generateNetworkDiagram(system: System): string {
     // Identify top level components (ones without execution environments) and generate markup recursively.
     output += generateComponents(Array.from(topLevelComponents.values()), componentsToRender);
     // Filter in relationships that connect to an execution environment & generate markup.
-    output += generateRelationships(Object.values(system.relationships));
+    output += generateRelationships(system.relationships);
     output += endUml();
     return output;
 }

--- a/src/syntax/components.ts
+++ b/src/syntax/components.ts
@@ -1,0 +1,173 @@
+import { API, Cache, Component, ComponentConfiguration, Database, Device, Domain, ExecutionEnvironment, Processor, Queue, Service, UI } from "../models";
+export { ComponentType } from '../models';
+
+
+export function ui(label: string, parentComponent?: Component): UI;
+export function ui(config: ComponentConfiguration): UI;
+export function ui(config: ComponentConfiguration[]): UI[];
+export function ui(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): UI | UI[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((uiConfig) => new UI(uiConfig.label, uiConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new UI(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new UI(config.label, config);
+        }
+    }
+}
+
+export function database(label: string, parentComponent?: Component): Database;
+export function database(config: ComponentConfiguration): Database;
+export function database(config: ComponentConfiguration[]): Database[];
+export function database(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Database | Database[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Database(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Database(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Database(config.label, config);
+        }
+    }
+}
+
+export function service(label: string, parentComponent?: Component): Service;
+export function service(config: ComponentConfiguration): Service;
+export function service(config: ComponentConfiguration[]): Service[];
+export function service(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Service | Service[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Service(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Service(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Service(config.label, config);
+        }
+    }
+}
+
+export function api(label: string, parentComponent?: Component): API;
+export function api(config: ComponentConfiguration): API;
+export function api(config: ComponentConfiguration[]): API[];
+export function api(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): API | API[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new API(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new API(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new API(config.label, config);
+        }
+    }
+}
+
+export function queue(label: string, parentComponent?: Component): Queue;
+export function queue(config: ComponentConfiguration): Queue;
+export function queue(config: ComponentConfiguration[]): Queue[];
+export function queue(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Queue | Queue[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Queue(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Queue(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Queue(config.label, config);
+        }
+    }
+}
+
+export function cache(label: string, parentComponent?: Component): Cache;
+export function cache(config: ComponentConfiguration): Cache;
+export function cache(config: ComponentConfiguration[]): Cache[];
+export function cache(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Cache | Cache[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Cache(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Cache(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Cache(config.label, config);
+        }
+    }
+}
+
+export function processor(label: string, parentComponent?: Component): Processor;
+export function processor(config: ComponentConfiguration): Processor;
+export function processor(config: ComponentConfiguration[]): Processor[];
+export function processor(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Processor | Processor[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Processor(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Processor(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Processor(config.label, config);
+        }
+    }
+}
+
+export function domain(label: string, parentComponent?: Component): Domain;
+export function domain(config: ComponentConfiguration): Domain;
+export function domain(config: ComponentConfiguration[]): Domain[];
+export function domain(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Domain | Domain[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Domain(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Domain(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Domain(config.label, config);
+        }
+    }
+}
+
+export function device(label: string, parentComponent?: Component): Device;
+export function device(config: ComponentConfiguration): Device;
+export function device(config: ComponentConfiguration[]): Device[];
+export function device(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Device | Device[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Device(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new Device(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Device(config.label, config);
+        }
+    }
+}
+
+export function executionEnvironment(label: string, parentComponent?: Component): ExecutionEnvironment;
+export function executionEnvironment(config: ComponentConfiguration): ExecutionEnvironment;
+export function executionEnvironment(config: ComponentConfiguration[]): ExecutionEnvironment[];
+export function executionEnvironment(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): ExecutionEnvironment | ExecutionEnvironment[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new ExecutionEnvironment(dbConfig.label, dbConfig));
+    } else {
+        if (labelOrConfig instanceof String) {
+            const label = labelOrConfig as string;
+            return new ExecutionEnvironment(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new ExecutionEnvironment(config.label, config);
+        }
+    }
+}

--- a/src/syntax/components.ts
+++ b/src/syntax/components.ts
@@ -9,7 +9,7 @@ export function ui(labelOrConfig: string | ComponentConfiguration | ComponentCon
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((uiConfig) => new UI(uiConfig.label, uiConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new UI(label, { parentComponent });
         } else {
@@ -26,7 +26,7 @@ export function database(labelOrConfig: string | ComponentConfiguration | Compon
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Database(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Database(label, { parentComponent });
         } else {
@@ -43,7 +43,7 @@ export function service(labelOrConfig: string | ComponentConfiguration | Compone
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Service(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Service(label, { parentComponent });
         } else {
@@ -60,7 +60,7 @@ export function api(labelOrConfig: string | ComponentConfiguration | ComponentCo
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new API(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new API(label, { parentComponent });
         } else {
@@ -77,7 +77,7 @@ export function queue(labelOrConfig: string | ComponentConfiguration | Component
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Queue(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Queue(label, { parentComponent });
         } else {
@@ -94,7 +94,7 @@ export function cache(labelOrConfig: string | ComponentConfiguration | Component
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Cache(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Cache(label, { parentComponent });
         } else {
@@ -111,7 +111,7 @@ export function processor(labelOrConfig: string | ComponentConfiguration | Compo
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Processor(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Processor(label, { parentComponent });
         } else {
@@ -128,7 +128,7 @@ export function domain(labelOrConfig: string | ComponentConfiguration | Componen
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Domain(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Domain(label, { parentComponent });
         } else {
@@ -145,7 +145,7 @@ export function device(labelOrConfig: string | ComponentConfiguration | Componen
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new Device(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new Device(label, { parentComponent });
         } else {
@@ -162,7 +162,7 @@ export function executionEnvironment(labelOrConfig: string | ComponentConfigurat
     if (labelOrConfig instanceof Array) {
         return labelOrConfig.map((dbConfig) => new ExecutionEnvironment(dbConfig.label, dbConfig));
     } else {
-        if (labelOrConfig instanceof String) {
+        if (typeof labelOrConfig === "string") {
             const label = labelOrConfig as string;
             return new ExecutionEnvironment(label, { parentComponent });
         } else {

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './relationships';
+export * from './system';

--- a/src/syntax/relationships.ts
+++ b/src/syntax/relationships.ts
@@ -1,0 +1,92 @@
+import { ComponentRelationshipConfiguration, Uses, Accesses, FlowsInto, Provides, Requires, ConnectsTo } from "../models";
+import { Component } from "../models/component";
+
+export function uses(source: Component, target: Component, description?: string): Uses;
+export function uses(config: ComponentRelationshipConfiguration): Uses;
+export function uses(config: ComponentRelationshipConfiguration[]): Uses[];
+export function uses(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): Uses | Uses[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new Uses(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new Uses(sourceOrConfig as Component, target, description);
+        }
+        return new Uses(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}
+
+export function accesses(source: Component, target: Component, description?: string): Accesses;
+export function accesses(config: ComponentRelationshipConfiguration): Accesses;
+export function accesses(config: ComponentRelationshipConfiguration[]): Accesses[];
+export function accesses(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): Accesses | Accesses[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new Accesses(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new Accesses(sourceOrConfig as Component, target, description);
+        }
+        return new Accesses(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}
+
+export function flowsInto(source: Component, target: Component, description?: string): FlowsInto;
+export function flowsInto(config: ComponentRelationshipConfiguration): FlowsInto;
+export function flowsInto(config: ComponentRelationshipConfiguration[]): FlowsInto[];
+export function flowsInto(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): FlowsInto | FlowsInto[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new FlowsInto(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new FlowsInto(sourceOrConfig as Component, target, description);
+        }
+        return new FlowsInto(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}
+
+export function provides(source: Component, target: Component, description?: string): Provides;
+export function provides(config: ComponentRelationshipConfiguration): Provides;
+export function provides(config: ComponentRelationshipConfiguration[]): Provides[];
+export function provides(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): Provides | Provides[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new Provides(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new Provides(sourceOrConfig as Component, target, description);
+        }
+        return new Provides(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}
+
+export function requires(source: Component, target: Component, description?: string): Requires;
+export function requires(config: ComponentRelationshipConfiguration): Requires;
+export function requires(config: ComponentRelationshipConfiguration[]): Requires[];
+export function requires(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): Requires | Requires[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new Requires(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new Requires(sourceOrConfig as Component, target, description);
+        }
+        return new Requires(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}
+
+export function connectsTo(source: Component, target: Component, description?: string): ConnectsTo;
+export function connectsTo(config: ComponentRelationshipConfiguration): ConnectsTo;
+export function connectsTo(config: ComponentRelationshipConfiguration[]): ConnectsTo[];
+export function connectsTo(sourceOrConfig: Component | ComponentRelationshipConfiguration | ComponentRelationshipConfiguration[], target?: Component, description?: string): ConnectsTo | ConnectsTo[]  {
+    if (sourceOrConfig instanceof Array) {
+        const relationships = sourceOrConfig;
+        return relationships.map((relationship) => new ConnectsTo(relationship));
+    } else {
+        if (sourceOrConfig && target && description) {
+            return new ConnectsTo(sourceOrConfig as Component, target, description);
+        }
+        return new ConnectsTo(sourceOrConfig as ComponentRelationshipConfiguration);
+    }
+}

--- a/src/syntax/relationships.ts
+++ b/src/syntax/relationships.ts
@@ -9,7 +9,7 @@ export function uses(sourceOrConfig: Component | ComponentRelationshipConfigurat
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new Uses(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new Uses(sourceOrConfig as Component, target, description);
         }
         return new Uses(sourceOrConfig as ComponentRelationshipConfiguration);
@@ -24,7 +24,7 @@ export function accesses(sourceOrConfig: Component | ComponentRelationshipConfig
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new Accesses(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new Accesses(sourceOrConfig as Component, target, description);
         }
         return new Accesses(sourceOrConfig as ComponentRelationshipConfiguration);
@@ -39,7 +39,7 @@ export function flowsInto(sourceOrConfig: Component | ComponentRelationshipConfi
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new FlowsInto(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new FlowsInto(sourceOrConfig as Component, target, description);
         }
         return new FlowsInto(sourceOrConfig as ComponentRelationshipConfiguration);
@@ -54,7 +54,7 @@ export function provides(sourceOrConfig: Component | ComponentRelationshipConfig
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new Provides(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new Provides(sourceOrConfig as Component, target, description);
         }
         return new Provides(sourceOrConfig as ComponentRelationshipConfiguration);
@@ -69,7 +69,7 @@ export function requires(sourceOrConfig: Component | ComponentRelationshipConfig
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new Requires(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new Requires(sourceOrConfig as Component, target, description);
         }
         return new Requires(sourceOrConfig as ComponentRelationshipConfiguration);
@@ -84,7 +84,7 @@ export function connectsTo(sourceOrConfig: Component | ComponentRelationshipConf
         const relationships = sourceOrConfig;
         return relationships.map((relationship) => new ConnectsTo(relationship));
     } else {
-        if (sourceOrConfig && target && description) {
+        if (sourceOrConfig && target) {
             return new ConnectsTo(sourceOrConfig as Component, target, description);
         }
         return new ConnectsTo(sourceOrConfig as ComponentRelationshipConfiguration);

--- a/src/syntax/system.ts
+++ b/src/syntax/system.ts
@@ -1,0 +1,13 @@
+import { System, SystemConfiguration } from "../models";
+
+//Overload Signatures
+export function system(config: SystemConfiguration): System;
+export function system(config: SystemConfiguration[]): System[];
+
+export function system(config): System | System[] {
+    if (config instanceof Array) {
+        return config.map((systemConfig) => new System(systemConfig));
+    } else {
+        return new System(config);
+    }
+}


### PR DESCRIPTION
- Restructure API, base syntax off functions w/ overloads for creating a single component w/ simple params, full config and a collection.
- Change interfaces to use arrays instead of objects, better for parsing & components for re-use get exported anyway.
- Simplify project exports
- Bugfixes