### PR TITLE
Add topic and eventQueue to syntax

### DIFF
--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -1,4 +1,4 @@
-import { System } from ".";
+import { ComponentRelationship, System } from ".";
 import { escapeString } from "../common/utils";
 
 export class Component implements ComponentConfiguration {
@@ -74,7 +74,17 @@ export class API extends Component {
 
 export class Queue extends Component {
     type = ComponentType.Queue;
+    stereotype = "Queue"
 }
+
+export class Topic extends Queue {
+    type = ComponentType.Topic;
+}
+
+export class EventQueue extends Queue {
+    type = ComponentType.EventQueue;
+}
+
 
 export class Cache extends Component {
     type = ComponentType.Database;
@@ -118,4 +128,6 @@ export enum ComponentType {
     Queue = "Queue",
     Processor = "Processor",
     Schema = "Schema",
+    Topic = "Topic",
+    EventQueue = "Event Queue",
 }

--- a/src/plantuml/component-diagram.ts
+++ b/src/plantuml/component-diagram.ts
@@ -17,7 +17,9 @@ export function getComponentDiagramType(type: ComponentType): string {
             return "node";
         case ComponentType.API:
             return "interface";
+        case ComponentType.Topic:
         case ComponentType.Queue:
+        case ComponentType.EventQueue:
             return "queue";
         case ComponentType.Processor:
                 return "control";

--- a/src/plantuml/deployment-diagram.ts
+++ b/src/plantuml/deployment-diagram.ts
@@ -19,6 +19,8 @@ export function getDeploymentDiagramType(type: ComponentType): string {
         case ComponentType.API:
             return "interface";
         case ComponentType.Queue:
+        case ComponentType.Topic:
+        case ComponentType.EventQueue:
             return "queue";
         case ComponentType.Processor:
             return "control";

--- a/src/syntax/components.ts
+++ b/src/syntax/components.ts
@@ -1,4 +1,4 @@
-import { API, Cache, Component, ComponentConfiguration, Database, Device, Domain, ExecutionEnvironment, Processor, Queue, Service, UI, Schema } from "../models";
+import { API, Cache, Component, ComponentConfiguration, Database, Device, Domain, ExecutionEnvironment, Processor, Queue, Service, UI, Schema, Topic, EventQueue } from "../models";
 export { ComponentType } from '../models';
 
 
@@ -66,6 +66,40 @@ export function api(labelOrConfig: string | ComponentConfiguration | ComponentCo
         } else {
             const config = labelOrConfig as ComponentConfiguration;
             return new API(config.label, config);
+        }
+    }
+}
+
+export function topic(label: string, parentComponent?: Component): Topic;
+export function topic(config: ComponentConfiguration): Topic;
+export function topic(config: ComponentConfiguration[]): Topic[];
+export function topic(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): Topic | Topic[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new Topic(dbConfig.label, dbConfig));
+    } else {
+        if (typeof labelOrConfig === "string") {
+            const label = labelOrConfig as string;
+            return new Topic(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new Topic(config.label, config);
+        }
+    }
+}
+
+export function eventQueue(label: string, parentComponent?: Component): EventQueue;
+export function eventQueue(config: ComponentConfiguration): EventQueue;
+export function eventQueue(config: ComponentConfiguration[]): EventQueue[];
+export function eventQueue(labelOrConfig: string | ComponentConfiguration | ComponentConfiguration[], parentComponent?: Component): EventQueue | EventQueue[]  {
+    if (labelOrConfig instanceof Array) {
+        return labelOrConfig.map((dbConfig) => new EventQueue(dbConfig.label, dbConfig));
+    } else {
+        if (typeof labelOrConfig === "string") {
+            const label = labelOrConfig as string;
+            return new EventQueue(label, { parentComponent });
+        } else {
+            const config = labelOrConfig as ComponentConfiguration;
+            return new EventQueue(config.label, config);
         }
     }
 }


### PR DESCRIPTION
Add basic support for `topic(...)` and `eventQueue(...)` to syntax, will come back to this later to automatically generate interfaces which can be optionally used in relationships.